### PR TITLE
Adds release workflow for app Docker Images in GitHub Container registry

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,68 @@
+name: Chatbot LLM Service Package (GitHub)
+
+# Configures this workflow to run every time a release is created.
+on:
+  release:
+    types: [created]
+
+# Defines custom environment variables for the workflow.
+env:
+  # Container registry domain
+  REGISTRY: ghcr.io
+  # Name for the Docker image that this workflow builds.
+  IMAGE_NAME: ${{ github.repository }}
+
+# The jobs that the workflow will run.
+jobs:
+
+  # Build and push job
+  build-and-push-image:
+    # Run on the latest available version of Ubuntu.
+    runs-on: ubuntu-latest
+
+    # Sets the permissions granted to the GITHUB_TOKEN for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    # Job execution steps
+    steps:
+      # Checkout repository
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # Uses the docker/login-action action to log in to the Container registry using the account and password that will publish the packages.
+      - name: Log in to the Container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extracts tags and labels that will be applied to the specified image.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Builds the image, based on the Dockerfile. If the build succeeds, it will push the image to GitHub Packages.
+      # Uses the tags and labels from the previous step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: ./docker/
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Generates an artifact attestation for the image.
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/helm-chart/templates/agent-configuration.yaml
+++ b/helm-chart/templates/agent-configuration.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -75,7 +75,7 @@ image:
   registry: ghcr.io
 
   # The repository name of the application image.
-  repository: t2ps-chatbot-llm
+  repository: statnett/Talk2PowerSystem_LLM
 
   # Image tag that corresponds to the version of application.
   # By default, the chart uses .Chart.AppVersion to construct the full image name.
@@ -295,14 +295,16 @@ serviceAccount:
 # Resource Configuration #
 ##########################
 
+# TODO: Speak with Neli about resource requirements.
+
 # Resource configurations for the containers.
 #
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/
 resources:
   requests:
-    memory: 256Mi
-  limits:
     memory: 1Gi
+  limits:
+    memory: 2Gi
 
 #########################
 # Probes Configurations #


### PR DESCRIPTION
- Added workflow for releasing Docker images for the application in the GitHub Container registry.

  As a workflow trigger is used the creation of a new release in GitHub. The version of the release will be used as version for the image when the tags are created.