### PR TITLE
SN-184 Fixes the provisioning of the boolean types configurations (Helm)

### DIFF
--- a/.github/workflows/_pull_requests.yml
+++ b/.github/workflows/_pull_requests.yml
@@ -3,8 +3,12 @@ name: tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'helm-chart/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'helm-chart/**'
 
 jobs:
   test:

--- a/helm-chart/templates/configuration-properties.yaml
+++ b/helm-chart/templates/configuration-properties.yaml
@@ -14,7 +14,7 @@ data:
   {{- if .Values.configuration.properties }}
     {{- range $key, $val := .Values.configuration.properties -}}
       {{- if ne $val nil }}
-        {{- $key | nindent 2 }}: {{ tpl ($val | toString) $ }}
+        {{- $key | nindent 2 }}: {{ tpl ($val | toString) $ | quote }}
       {{- end }}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
- Added quoting for the configuration properties values transferred from the `values.yaml` to the ConfigMap.

  There is an issue with the boolean value types, where they have to be rendered as strings. By additionally quoting the value, we can avoid such cases, when deploying new versions and there are similar configurations.