### PR TITLE
Statnett-363: Access to Cognite with a service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+v2.3.0-rc1
+============
+
+* [#363](https://github.com/statnett/Talk2PowerSystem_PM/issues/363):
+  - Implement access to Cognite with a service account.
+  - Environment variable `COGNITE_CLIENT_SECRET`
+  (`tools.cognite.client_secret` in the agent config) used for OBO 
+  authentication to Cognite is renamed to `COGNITE_OBO_CLIENT_SECRET`
+  (`tools.cognite.obo_client_secret` in the agent config).
+  - Bring back Cognite health check for deployments with service 
+    account or with a token from a file.
+    For deployments with OBO authentication, the health check is disabled.
+  - Update `langchain-openai` to `1.2.0`,
+    `langgraph-checkpoint-redis` to `0.4.1`, `cognite-sdk` to `8.1.0`, 
+    `pydantic-settings` to `2.14.0`, `uvicorn` to `0.46.0`,
+    `fastapi` to `0.136.0`, `msal` to `1.36.0`, `cachetools` to `7.0.6`, 
+    `importlib_resources` to `7.1.0`, update some other transitive 
+    dependencies to their latest versions to address the security 
+    vulnerabilities.
+* [#362](https://github.com/statnett/Talk2PowerSystem_PM/issues/362):
+  Use `RNDP_mrid` metadata instead of `mrid` for time series.
+  Add hard filter for timeseries having `RNDP_mrid` metadata.
+
 v2.2.0-rc1
 ============
 

--- a/docs/AgentConfig.md
+++ b/docs/AgentConfig.md
@@ -164,11 +164,25 @@ LIMIT {limit}
 - `tools.cognite.project` - OPTIONAL, DEFAULT=`prod` - Cognite Data Fusion project name.
 One of `dev1`, `dev2`, `dev3`, `test`, `prod` according to [CDF access from RNDP](https://github.com/statnett/Talk2PowerSystem_PM/wiki/CDF-access-from-RNDP).
 - `tools.cognite.client_name` - OPTIONAL, DEFAULT=`talk2powersystem` - Name of the client for logging purposes.
-- `tools.cognite.interactive_client_id` - OPTIONAL - If provided, interactive authentication is used (when you run on a dev machine the backend app with uvicorn or the Jupyter Notebook).
-  Otherwise, `tools.cognite.token_file_path` or `tools.cognite.client_secret` must be provided.
-- `tools.cognite.tenant_id` - REQUIRED iff `tools.cognite.interactive_client_id` is present - Azure tenant ID. For example, `a8d61462-f252-44b2-bf6a-d7231960c041`.
-- `tools.cognite.token_file_path` - OPTIONAL - Full path on the disk to the cognite token file (used when you run the Jupyter Notebook on RNDP). For example, `/var/run/secrets/microsoft.com/entra/cognite`.
-* `tools.cognite.client_secret` - OPTIONAL - Client secret for the Cognite confidential application (used for the backend app running on RNDP).
+
+There are 4 ways to authenticate against Cognite. One and only one of `tools.cognite.interactive_client_id`,
+`tools.cognite.client_id`, `tools.cognite.token_file_path`, or `tools.cognite.obo_client_secret` must be provided.
+
+- `tools.cognite.interactive_client_id` - OPTIONAL - If provided, interactive authentication is used.
+  (when you run on a dev machine the backend app with uvicorn or the Jupyter Notebook).
+- `tools.cognite.client_id` - OPTIONAL - If provided, service account authentication is used.
+  (backend app with service account authentication, ex: backend app running on cim.ontotext).
+* `tools.cognite.client_secret` - REQUIRED iff service account authentication is used -
+  Client secret for the service account. Can also be set using the environment variable `COGNITE_CLIENT_SECRET`.
+- `tools.cognite.tenant_id` - REQUIRED iff interactive authentication or service account authentication is used -
+  Azure tenant ID. For example, `a8d61462-f252-44b2-bf6a-d7231960c041`.
+- `tools.cognite.token_file_path` - OPTIONAL - Full path on the disk to the 
+  Cognite token file.
+  (used when you run the Jupyter Notebook on RNDP, or backend app with token authentication).
+  For example, `/var/run/secrets/microsoft.com/entra/cognite`.
+* `tools.cognite.obo_client_secret` - OPTIONAL - Client secret for the Cognite confidential application.
+  Can also be set using the environment variable `COGNITE_OBO_CLIENT_SECRET`.
+  (used for the backend app running on RNDP).
 
 ## `llm`
 
@@ -210,3 +224,5 @@ Check OpenAI documentation for supported values and models.
 
 - `LLM_API_KEY` - REQUIRED - API key for authentication to Azure OpenAI or OpenAI
 - `GRAPHDB_PASSWORD` - REQUIRED, iff `graphdb.username` is set - Password for the GraphDB user
+- `COGNITE_CLIENT_SECRET` - REQUIRED, iff `tools.cognite.client_id` is set - Client secret for the Cognite service account.
+- `COGNITE_OBO_CLIENT_SECRET` - REQUIRED, iff OBO Cognite authentication flow is required - Client secret for the Cognite confidential application.

--- a/helm-chart/CHANGELOG.md
+++ b/helm-chart/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Talk to the Power System Chatbot LLM
 
+## 1.3.1
+
+- Update `appVersion` to `v2.3.0-rc1`.
+
 ## 1.3.0
 
 - Update `appVersion` to `v2.2.0-rc1` and remove `agent.llm.temperature` and 

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: t2ps-chatbot-llm
 description: Python application for the Talk to the Power System Chatbot LLM
 type: application
-version: 1.3.0
-appVersion: "v2.2.0-rc1"
+version: 1.3.1
+appVersion: "v2.3.0-rc1"
 home: https://github.com/statnett/Talk2PowerSystem_LLM
 sources:
   - https://github.com/statnett/Talk2PowerSystem_LLM

--- a/poetry.lock
+++ b/poetry.lock
@@ -200,18 +200,19 @@ files = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.0"
 description = "The ultimate Python library in building OAuth and OpenID Connect servers and clients."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3"},
-    {file = "authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04"},
+    {file = "authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0"},
+    {file = "authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5"},
 ]
 
 [package.dependencies]
 cryptography = "*"
+joserfc = ">=1.6.0"
 
 [[package]]
 name = "babel"
@@ -272,14 +273,14 @@ css = ["tinycss2 (>=1.1.0,<1.5)"]
 
 [[package]]
 name = "cachetools"
-version = "7.0.5"
+version = "7.0.6"
 description = "Extensible memoizing collections and decorators"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "cachetools-7.0.5-py3-none-any.whl", hash = "sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114"},
-    {file = "cachetools-7.0.5.tar.gz", hash = "sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990"},
+    {file = "cachetools-7.0.6-py3-none-any.whl", hash = "sha256:4e94956cfdd3086f12042cdd29318f5ced3893014f7d0d059bf3ead3f85b7f8b"},
+    {file = "cachetools-7.0.6.tar.gz", hash = "sha256:e5d524d36d65703a87243a26ff08ad84f73352adbeafb1cde81e207b456aaf24"},
 ]
 
 [[package]]
@@ -547,14 +548,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognite-sdk"
-version = "8.0.5"
+version = "8.1.0"
 description = "Cognite Python SDK"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "cognite_sdk-8.0.5-py3-none-any.whl", hash = "sha256:d49cd5d3b2c90c8afcd46fa1c000debc4ee2a2e510920b4c38a4860fd73ed8d5"},
-    {file = "cognite_sdk-8.0.5.tar.gz", hash = "sha256:6232dd6c9e4896f40dc516cca958ee94333732c9a60796a20171dc7867115b5b"},
+    {file = "cognite_sdk-8.1.0-py3-none-any.whl", hash = "sha256:f1d720b97aba4591061dd4468e60c58b6680801e96e8bfc46638aa2e9e870e1e"},
+    {file = "cognite_sdk-8.1.0.tar.gz", hash = "sha256:20bb2ced12ee21f4569d90c24234e62f2735173a2ae8c6db22aa7fbfd64b42c7"},
 ]
 
 [package.dependencies]
@@ -724,61 +725,61 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "46.0.6"
+version = "46.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main"]
 files = [
-    {file = "cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19"},
-    {file = "cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738"},
-    {file = "cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c"},
-    {file = "cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f"},
-    {file = "cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2"},
-    {file = "cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124"},
-    {file = "cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4"},
-    {file = "cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a"},
-    {file = "cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d"},
-    {file = "cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736"},
-    {file = "cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed"},
-    {file = "cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4"},
-    {file = "cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa"},
-    {file = "cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58"},
-    {file = "cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb"},
-    {file = "cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72"},
-    {file = "cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c"},
-    {file = "cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:2ea0f37e9a9cf0df2952893ad145fd9627d326a59daec9b0802480fa3bcd2ead"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a3e84d5ec9ba01f8fd03802b2147ba77f0c8f2617b2aff254cedd551844209c8"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:12f0fa16cc247b13c43d56d7b35287ff1569b5b1f4c5e87e92cc4fcc00cd10c0"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:50575a76e2951fe7dbd1f56d181f8c5ceeeb075e9ff88e7ad997d2f42af06e7b"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:90e5f0a7b3be5f40c3a0a0eafb32c681d8d2c181fc2a1bdabe9b3f611d9f6b1a"},
-    {file = "cryptography-46.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6728c49e3b2c180ef26f8e9f0a883a2c585638db64cf265b49c9ba10652d430e"},
-    {file = "cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759"},
+    {file = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e"},
+    {file = "cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457"},
+    {file = "cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"},
+    {file = "cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb"},
+    {file = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e"},
+    {file = "cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246"},
+    {file = "cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4"},
+    {file = "cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"},
 ]
 
 [package.dependencies]
@@ -791,7 +792,7 @@ nox = ["nox[uv] (>=2024.4.15)"]
 pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
 sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==46.0.6)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -906,14 +907,14 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "fastapi"
-version = "0.135.3"
+version = "0.136.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98"},
-    {file = "fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654"},
+    {file = "fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4"},
+    {file = "fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e"},
 ]
 
 [package.dependencies]
@@ -925,7 +926,7 @@ typing-inspection = ">=0.4.2"
 
 [package.extras]
 all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "uvicorn[standard] (>=0.12.0)"]
-standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "fastar (>=0.9.0)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
@@ -1099,23 +1100,23 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "importlib-resources"
-version = "6.5.2"
+version = "7.1.0"
 description = "Read resources from Python packages"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec"},
-    {file = "importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c"},
+    {file = "importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1"},
+    {file = "importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
+enabler = ["pytest-enabler (>=3.4)"]
 test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
-type = ["pytest-mypy"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [[package]]
 name = "iniconfig"
@@ -1396,6 +1397,24 @@ files = [
     {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19"},
     {file = "jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4"},
 ]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+description = "The ultimate Python library for JOSE RFCs, including JWS, JWE, JWK, JWA, JWT"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a"},
+    {file = "joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c"},
+]
+
+[package.dependencies]
+cryptography = ">=45.0.1"
+
+[package.extras]
+drafts = ["pycryptodome"]
 
 [[package]]
 name = "json5"
@@ -1816,14 +1835,14 @@ xai = ["langchain-xai"]
 
 [[package]]
 name = "langchain-core"
-version = "1.2.22"
+version = "1.3.0"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
 files = [
-    {file = "langchain_core-1.2.22-py3-none-any.whl", hash = "sha256:7e30d586b75918e828833b9ec1efc25465723566845dd652c277baf751e9c04b"},
-    {file = "langchain_core-1.2.22.tar.gz", hash = "sha256:8d8f726d03d3652d403da915126626bb6250747e8ba406537d849e68b9f5d058"},
+    {file = "langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced"},
+    {file = "langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046"},
 ]
 
 [package.dependencies]
@@ -1838,18 +1857,18 @@ uuid-utils = ">=0.12.0,<1.0"
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.12"
+version = "1.2.0"
 description = "An integration package connecting OpenAI and LangChain"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
 files = [
-    {file = "langchain_openai-1.1.12-py3-none-any.whl", hash = "sha256:da71ca3f2d18c16f7a2443cc306aa195ad2a07054335ac9b0626dcae02b6a0c5"},
-    {file = "langchain_openai-1.1.12.tar.gz", hash = "sha256:ccf5ef02c896f6807b4d0e51aaf678a72ce81ae41201cae8d65e11eeff9ecb79"},
+    {file = "langchain_openai-1.2.0-py3-none-any.whl", hash = "sha256:b3ed14dc48e40890605136f26c6b07e8f293987d95e734ab67cbfa572c523456"},
+    {file = "langchain_openai-1.2.0.tar.gz", hash = "sha256:e88edf16002b9ed8e206161181c8a6fb2b3662da23195e0a844d040c3f93ab10"},
 ]
 
 [package.dependencies]
-langchain-core = ">=1.2.21,<2.0.0"
+langchain-core = ">=1.3.0,<2.0.0"
 openai = ">=2.26.0,<3.0.0"
 tiktoken = ">=0.7.0,<1.0.0"
 
@@ -1891,14 +1910,14 @@ ormsgpack = ">=1.12.0"
 
 [[package]]
 name = "langgraph-checkpoint-redis"
-version = "0.4.0"
+version = "0.4.1"
 description = "Redis implementation of the LangGraph agent checkpoint saver and store."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "langgraph_checkpoint_redis-0.4.0-py3-none-any.whl", hash = "sha256:ba8e48943fd056bae55a87284ab47159e23ca0038a1491374f65564c1af99a35"},
-    {file = "langgraph_checkpoint_redis-0.4.0.tar.gz", hash = "sha256:7db66f4c5919c7d939fe6d62c5f9a4c5147434142eca6cdad9fd470d11ccfb74"},
+    {file = "langgraph_checkpoint_redis-0.4.1-py3-none-any.whl", hash = "sha256:c79da90c1e3421bbeac6d2d3b9e2f10892297b19ef830d37bf9125ba0880f9d9"},
+    {file = "langgraph_checkpoint_redis-0.4.1.tar.gz", hash = "sha256:499fecf341d0128f932ad784472de27bc56579d8fd16f7aec425842c17f40521"},
 ]
 
 [package.dependencies]
@@ -1941,14 +1960,14 @@ orjson = ">=3.11.5"
 
 [[package]]
 name = "langsmith"
-version = "0.7.22"
+version = "0.7.33"
 description = "Client library to connect to the LangSmith Observability and Evaluation Platform."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "langsmith-0.7.22-py3-none-any.whl", hash = "sha256:6e9d5148314d74e86748cb9d3898632cad0320c9323d95f70f969e5bc078eee4"},
-    {file = "langsmith-0.7.22.tar.gz", hash = "sha256:35bfe795d648b069958280760564632fd28ebc9921c04f3e209c0db6a6c7dc04"},
+    {file = "langsmith-0.7.33-py3-none-any.whl", hash = "sha256:5b535b991d52d3b664ebb8dc6f95afcf8d0acb42e062ac45a54a6a4820139f20"},
+    {file = "langsmith-0.7.33.tar.gz", hash = "sha256:fa2d81ad6e8374a81fda9291894f6fcae714e55fbf11a0b07578e3cd4b1ea384"},
 ]
 
 [package.dependencies]
@@ -2206,14 +2225,14 @@ requests = "*"
 
 [[package]]
 name = "msal"
-version = "1.35.1"
+version = "1.36.0"
 description = "The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "msal-1.35.1-py3-none-any.whl", hash = "sha256:8f4e82f34b10c19e326ec69f44dc6b30171f2f7098f3720ea8a9f0c11832caa3"},
-    {file = "msal-1.35.1.tar.gz", hash = "sha256:70cac18ab80a053bff86219ba64cfe3da1f307c74b009e2da57ef040eb1b5656"},
+    {file = "msal-1.36.0-py3-none-any.whl", hash = "sha256:36ecac30e2ff4322d956029aabce3c82301c29f0acb1ad89b94edcabb0e58ec4"},
+    {file = "msal-1.36.0.tar.gz", hash = "sha256:3f6a4af2b036b476a4215111c4297b4e6e236ed186cd804faefba23e4990978b"},
 ]
 
 [package.dependencies]
@@ -2249,14 +2268,14 @@ test = ["flaky", "ipykernel (>=6.19.3)", "ipython", "ipywidgets", "nbconvert (>=
 
 [[package]]
 name = "nbconvert"
-version = "7.17.0"
+version = "7.17.1"
 description = "Convert Jupyter Notebooks (.ipynb files) to other formats."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "nbconvert-7.17.0-py3-none-any.whl", hash = "sha256:4f99a63b337b9a23504347afdab24a11faa7d86b405e5c8f9881cd313336d518"},
-    {file = "nbconvert-7.17.0.tar.gz", hash = "sha256:1b2696f1b5be12309f6c7d707c24af604b87dfaf6d950794c7b07acab96dda78"},
+    {file = "nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8"},
+    {file = "nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2"},
 ]
 
 [package.dependencies]
@@ -2993,14 +3012,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.0"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237"},
-    {file = "pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025"},
+    {file = "pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e"},
+    {file = "pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d"},
 ]
 
 [package.dependencies]
@@ -3009,7 +3028,7 @@ python-dotenv = ">=0.21.0"
 typing-inspection = ">=0.4.0"
 
 [package.extras]
-aws-secrets-manager = ["boto3 (>=1.35.0)", "boto3-stubs[secretsmanager]"]
+aws-secrets-manager = ["boto3 (>=1.35.0)", "types-boto3[secretsmanager]"]
 azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
 gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
 toml = ["tomli (>=2.0.1)"]
@@ -3068,14 +3087,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["test"]
 files = [
-    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
-    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
@@ -4326,14 +4345,14 @@ files = [
 
 [[package]]
 name = "uvicorn"
-version = "0.44.0"
+version = "0.46.0"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89"},
-    {file = "uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e"},
+    {file = "uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048"},
+    {file = "uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d"},
 ]
 
 [package.dependencies]
@@ -4938,4 +4957,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "2da3149cb4af24d1715df12e6740e43760e2be9bed07f4abde12b0af964d1312"
+content-hash = "1dff9d4546de74b29203b9a4c4ea09e5e9793f13dd4df83349e4c0c3fc117cac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Talk2PowerSystemLLM"
-version = "2.2.0-rc1"
+version = "2.3.0-rc1"
 description = "Talk to Power System LLM"
 authors = []
 readme = "README.adoc"
@@ -10,28 +10,28 @@ dependencies = [
     "ttyg==4.2.0",
     "graphrag-eval==5.3.1",
     "jupyter==1.1.1",
-    "langchain-openai==1.1.12",
-    "langgraph-checkpoint-redis==0.4.0",
+    "langchain-openai==1.2.0",
+    "langgraph-checkpoint-redis==0.4.1",
     "jsonlines==4.0.0",
-    "cognite-sdk==8.0.5",
-    "pydantic-settings==2.13.1",
+    "cognite-sdk==8.1.0",
+    "pydantic-settings==2.14.0",
     "PyYAML==6.0.3",
-    "uvicorn[standard]==0.44.0",
-    "fastapi==0.135.3",
+    "uvicorn[standard]==0.46.0",
+    "fastapi==0.136.0",
     "APScheduler==3.11.2",
     "toml==0.10.2",
     "markdown==3.10.2",
     "python-jose[cryptography]==3.5.0",
-    "msal==1.35.1",
-    "cachetools==7.0.5",
-    "importlib_resources==6.5.2",
+    "msal==1.36.0",
+    "cachetools==7.0.6",
+    "importlib_resources==7.1.0",
 ]
 
 [project.urls]
 repository = "https://github.com/statnett/Talk2PowerSystem_LLM"
 
 [tool.poetry.group.test.dependencies]
-pytest = "<10,>=9"
+pytest = "<10,>=9.0.3"
 pytest-cov = "<8,>=7"
 pytest-asyncio = "<2,>=1"
 requests = "<3,>=2"

--- a/src/talk2powersystemllm/agent.py
+++ b/src/talk2powersystemllm/agent.py
@@ -72,7 +72,7 @@ class RetrievalSearchSettings(BaseModel):
     sparql_query_template: str
 
 
-class CogniteSettings(BaseModel):
+class CogniteSettings(BaseSettings):
     model_config = {
         "env_prefix": "COGNITE_",
     }
@@ -80,10 +80,12 @@ class CogniteSettings(BaseModel):
     base_url: str
     project: str = "prod"
     client_name: str = "talk2powersystem"
-    token_file_path: Path | None = None
     interactive_client_id: str | None = None
+    client_id: str | None = None
+    client_secret: SecretStr | None = None
     tenant_id: str | None = None
-    client_secret: str | None = None
+    token_file_path: Path | None = None
+    obo_client_secret: SecretStr | None = None
 
     @model_validator(mode="after")
     def check_credentials(self) -> "CogniteSettings":
@@ -91,14 +93,21 @@ class CogniteSettings(BaseModel):
             return sum(a is not None for a in args) == 1
 
         if not exactly_one_is_not_none(
-            self.client_secret, self.token_file_path, self.interactive_client_id
+            self.interactive_client_id,
+            self.client_id,
+            self.token_file_path,
+            self.obo_client_secret,
         ):
             raise ValueError(
-                "Pass exactly one of 'client_secret', 'token_file_path' or 'interactive_client_id'!"
+                "Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+                "'obo_client_secret'!"
             )
 
-        if self.interactive_client_id and not self.tenant_id:
-            raise ValueError("Tenant id is required!")
+        if self.client_id and not self.client_secret:
+            raise ValueError("'client_secret' is required!")
+
+        if (self.interactive_client_id or self.client_id) and not self.tenant_id:
+            raise ValueError("'tenant_id' is required!")
         return self
 
 
@@ -169,10 +178,12 @@ class Talk2PowerSystemAgentFactory:
     model: BaseChatModel
     checkpointer: Checkpointer | None = None
     graphdb_client: GraphDB
+    cognite_session: CogniteSession | None
     tools: list[BaseTool]
     tools_metadata: dict[str, dict[str, Any]]
     tool_name_to_gdb_repository_id: dict[str, str]
     advanced_tools: set[str]
+    __agent: CompiledStateGraph | None
     __settings: Talk2PowerSystemAgentSettings
 
     def __init__(
@@ -181,11 +192,11 @@ class Talk2PowerSystemAgentFactory:
         checkpointer: Checkpointer | None = None,
     ):
         self.__init_settings(path_to_yaml_config)
-        self.__init_graphdb()
-        self.__init_tools()
-        self.__init_instructions()
-        self.__init_model()
         self.checkpointer = checkpointer
+        self.__init_model()
+        self.__init_graphdb()
+        self.__init_instructions()
+        self.__init_tools()
 
     def __init_settings(self, path_to_yaml_config: Path) -> None:
         config_path = Path(path_to_yaml_config).resolve()
@@ -292,16 +303,45 @@ class Talk2PowerSystemAgentFactory:
         self.tools.append(now_tool)
         self.tools_metadata["now"] = {"enabled": True}
 
-        cognite_enabled = bool(tools_settings.cognite)
+        cognite_settings = tools_settings.cognite
+        cognite_enabled = bool(cognite_settings)
         cognite_meta: dict[str, Any] = {"enabled": cognite_enabled}
 
+        self.cognite_session = None
+        self.__agent = None
         if cognite_enabled:
             cognite_meta.update(
                 {
-                    "base_url": tools_settings.cognite.base_url,
-                    "project": tools_settings.cognite.project,
-                    "client_name": tools_settings.cognite.client_name,
+                    "base_url": cognite_settings.base_url,
+                    "project": cognite_settings.project,
+                    "client_name": cognite_settings.client_name,
                 }
+            )
+
+            if (
+                cognite_settings.interactive_client_id
+                or cognite_settings.client_id
+                or cognite_settings.token_file_path
+            ):
+                self.cognite_session = self.__init_cognite()
+                self.tools.append(
+                    RetrieveTimeSeriesTool(cognite_session=self.cognite_session)
+                )
+                self.tools.append(
+                    RetrieveDataPointsTool(cognite_session=self.cognite_session)
+                )
+                self.__agent = create_agent(
+                    model=self.model,
+                    tools=self.tools,
+                    system_prompt=self.instructions,
+                    checkpointer=self.checkpointer,
+                )
+        else:
+            self.__agent = create_agent(
+                model=self.model,
+                tools=self.tools,
+                system_prompt=self.instructions,
+                checkpointer=self.checkpointer,
             )
 
         self.tools_metadata["retrieve_data_points"] = cognite_meta
@@ -376,24 +416,28 @@ class Talk2PowerSystemAgentFactory:
             project=cognite_settings.project,
             token_file_path=cognite_settings.token_file_path,
             interactive_client_id=cognite_settings.interactive_client_id,
+            client_id=cognite_settings.client_id,
+            client_secret=cognite_settings.client_secret,
             tenant_id=cognite_settings.tenant_id,
             obo_token=obo_token,
         )
 
     def get_agent(self, cognite_obo_token: str | None = None) -> CompiledStateGraph:
-        tools = self.tools
-        if self.cognite_enabled:
+        if self.__agent:
+            return self.__agent
+        else:
+            tools = self.tools
             cognite_session = self.__init_cognite(cognite_obo_token)
             tools = tools + [
                 RetrieveTimeSeriesTool(cognite_session=cognite_session),
                 RetrieveDataPointsTool(cognite_session=cognite_session),
             ]
-        return create_agent(
-            model=self.model,
-            tools=tools,
-            system_prompt=self.instructions,
-            checkpointer=self.checkpointer,
-        )
+            return create_agent(
+                model=self.model,
+                tools=tools,
+                system_prompt=self.instructions,
+                checkpointer=self.checkpointer,
+            )
 
     @property
     def graphdb_base_url(self) -> str:

--- a/src/talk2powersystemllm/app/server/lifespan.py
+++ b/src/talk2powersystemllm/app/server/lifespan.py
@@ -12,6 +12,7 @@ from redis.asyncio import Redis, RedisCluster
 
 from talk2powersystemllm.agent import Talk2PowerSystemAgentFactory
 from talk2powersystemllm.app.server.services import (
+    CogniteHealthchecker,
     GraphDBHealthchecker,
     HealthChecks,
     LLMHealthchecker,
@@ -57,16 +58,14 @@ async def lifespan(fastapi_app: FastAPI):
             fastapi_app.state.jwks_cache = TTLCache(
                 maxsize=1, ttl=settings.security.ttl
             )
-            if agent_factory.cognite_enabled:
-                if not agent_factory.cognite_settings.client_secret:
-                    raise ValueError(
-                        "Cognite client secret must be provided in order to register the Cognite tools, "
-                        "when the security is enabled."
-                    )
+            if (
+                agent_factory.cognite_enabled
+                and agent_factory.cognite_settings.obo_client_secret
+            ):
                 fastapi_app.state.confidential_app = msal.ConfidentialClientApplication(
                     settings.security.client_id,
                     authority=settings.security.authority,
-                    client_credential=agent_factory.cognite_settings.client_secret,
+                    client_credential=agent_factory.cognite_settings.obo_client_secret.get_secret_value(),
                 )
                 fastapi_app.state.cognite_scopes = [
                     f"{agent_factory.cognite_settings.base_url}/.default"
@@ -95,6 +94,8 @@ async def create_health_checks_registry(
     health_checks_registry = HealthChecks()
     health_checks_registry.add(GraphDBHealthchecker(agent_factory))
     health_checks_registry.add(RedisHealthchecker(redis_client))
+    if agent_factory.cognite_session:
+        health_checks_registry.add(CogniteHealthchecker(agent_factory.cognite_session))
     llm_health_check = LLMHealthchecker(redis_client)
     fastapi_app.state.callbacks = [llm_health_check]
     health_checks_registry.add(llm_health_check)

--- a/src/talk2powersystemllm/app/server/services/__init__.py
+++ b/src/talk2powersystemllm/app/server/services/__init__.py
@@ -4,6 +4,7 @@ from .chat_service import get_or_create_conversation, run_agent_loop
 from .explain_service import get_query_methods
 from .gtg_service import update_gtg_info
 from .healthchecks import (
+    CogniteHealthchecker,
     GraphDBHealthchecker,
     HealthChecks,
     LLMHealthchecker,
@@ -18,6 +19,7 @@ __all__ = [
     "run_agent_loop",
     "get_query_methods",
     "update_gtg_info",
+    "CogniteHealthchecker",
     "GraphDBHealthchecker",
     "HealthChecks",
     "LLMHealthchecker",

--- a/src/talk2powersystemllm/app/server/services/healthchecks/__init__.py
+++ b/src/talk2powersystemllm/app/server/services/healthchecks/__init__.py
@@ -1,9 +1,11 @@
+from .cognite_healthcheck import CogniteHealthchecker
 from .graphdb_healthcheck import GraphDBHealthchecker
 from .healthchecks import HealthChecks
 from .llm_healthcheck import LLMHealthchecker
 from .redis_healthcheck import RedisHealthchecker
 
 __all__ = [
+    "CogniteHealthchecker",
     "GraphDBHealthchecker",
     "HealthChecks",
     "LLMHealthchecker",

--- a/src/talk2powersystemllm/app/server/services/healthchecks/cognite_healthcheck.py
+++ b/src/talk2powersystemllm/app/server/services/healthchecks/cognite_healthcheck.py
@@ -1,0 +1,43 @@
+import logging
+
+from talk2powersystemllm.app.models import HealthCheck, HealthStatus, Severity
+from talk2powersystemllm.app.server.services.healthchecks.healthchecks import (
+    HealthProvider,
+)
+from talk2powersystemllm.tools import CogniteSession
+
+logger = logging.getLogger(__name__)
+
+
+class CogniteHealthcheck(HealthCheck):
+    severity: Severity = Severity.HIGH
+    id: str = "http://talk2powersystem.no/talk2powersystem-api/cognite-healthcheck"
+    name: str = "Cognite Health Check"
+    type: str = "cognite"
+    impact: str = (
+        "Chat bot won't be able to query Cognite or tools may not function as expected."
+    )
+    troubleshooting: str = "#cognite-health-check-status-is-not-ok"
+    description: str = (
+        "Checks if Cognite can be queried by listing the time series with limit of 1."
+    )
+
+
+class CogniteHealthchecker(HealthProvider):
+    def __init__(
+        self,
+        cognite_session: CogniteSession,
+    ):
+        self.__cognite_session = cognite_session
+
+    async def health(self) -> CogniteHealthcheck:
+        try:
+            self.__cognite_session.client().time_series.list(limit=1)
+            return CogniteHealthcheck(
+                status=HealthStatus.OK, message="Cognite can be queried."
+            )
+        except Exception as error:
+            logger.exception("Exception raised in Cognite health check")
+            return CogniteHealthcheck(
+                status=HealthStatus.ERROR, message="Cognite error " + str(error)
+            )

--- a/src/talk2powersystemllm/app/trouble.md
+++ b/src/talk2powersystemllm/app/trouble.md
@@ -761,7 +761,7 @@ Response Body JSON Schema:
 }
 ```
 
-Sample Response Body:
+Sample Response Body Without Cognite Health Check:
 
 ```json
 {
@@ -788,6 +788,60 @@ Sample Response Body:
       "troubleshooting": "http://localhost:8000/__trouble#graphdb-health-check-status-is-not-ok",
       "description": "Checks that the GraphDB repository can be queried and is healthy. Checks that the status of the autocomplete index is READY, and the RDF rank status is COMPUTED. In addition, if the n-shot tool is available, checks that the n-shot tool GraphDB repository can be queried and is healthy, and that the ChatGPT Retrieval Plugin connector exists and its status is healthy.",
       "message": "GraphDB can be queried, the setup is correct, and the state is healthy."
+    },
+    {
+      "status": "OK",
+      "severity": "HIGH",
+      "id": "http://talk2powersystem.no/talk2powersystem-api/llm-healthcheck",
+      "name": "LLM Health Check",
+      "type": "llm",
+      "impact": "Some requests to the chat bot failed during the last 60 seconds due to LLM errors!",
+      "troubleshooting": "http://localhost:8000/__trouble#llm-health-check-status-is-not-ok",
+      "description": "Checks if any LLM calls resulted in errors during the last 60 seconds!",
+      "message": "No LLM errors were hit in the last 60 seconds!"
+    }
+  ]
+}
+```
+
+Sample Response Body With Cognite Health Check:
+
+```json
+{
+  "status": "OK",
+  "healthChecks": [
+    {
+      "status": "OK",
+      "severity": "HIGH",
+      "id": "http://talk2powersystem.no/talk2powersystem-api/redis-healthcheck",
+      "name": "Redis Health Check",
+      "type": "redis",
+      "impact": "Redis is inaccessible and the chat bot can't function",
+      "troubleshooting": "http://localhost:8000/__trouble#redis-health-check-status-is-not-ok",
+      "description": "Checks if Redis can be queried.",
+      "message": "Redis can be queried."
+    },
+    {
+      "status": "OK",
+      "severity": "HIGH",
+      "id": "http://talk2powersystem.no/talk2powersystem-api/graphdb-healthcheck",
+      "name": "GraphDB Health Check",
+      "type": "graphdb",
+      "impact": "Chat bot won't be able to query GraphDB or tools may not function as expected.",
+      "troubleshooting": "http://localhost:8000/__trouble#graphdb-health-check-status-is-not-ok",
+      "description": "Checks that the GraphDB repository can be queried and is healthy. Checks that the status of the autocomplete index is READY, and the RDF rank status is COMPUTED. In addition, if the n-shot tool is available, checks that the n-shot tool GraphDB repository can be queried and is healthy, and that the ChatGPT Retrieval Plugin connector exists and its status is healthy.",
+      "message": "GraphDB can be queried, the setup is correct, and the state is healthy."
+    },
+    {
+      "status": "OK",
+      "severity": "HIGH",
+      "id": "http://talk2powersystem.no/talk2powersystem-api/cognite-healthcheck",
+      "name": "Cognite Health Check",
+      "type": "cognite",
+      "impact": "Chat bot won't be able to query Cognite or tools may not function as expected.",
+      "troubleshooting": "http://localhost:8000/__trouble#cognite-health-check-status-is-not-ok",
+      "description": "Checks if Cognite can be queried by listing the time series with limit of 1.",
+      "message": "Cognite can be queried."
     },
     {
       "status": "OK",
@@ -1809,6 +1863,10 @@ Most probable cause: [Cognite can't be queried or is misconfigured](#cognite-can
 
 Most probable cause: [Redis can't be queried or is misconfigured](#redis-cant-be-queried-or-is-misconfigured)
 
+#### Cognite health check status is not OK
+
+Most probable cause: [Cognite can't be queried or is misconfigured](#cognite-cant-be-queried-or-is-misconfigured)
+
 #### LLM health check status is not OK
 
 There are two probable causes:
@@ -1941,22 +1999,44 @@ Another option is to change the LLM system prompt, or the LLM model to a more ca
 
 ##### Solution
 
-- Make sure Cognite is reachable from the app host.
-- Make sure the application security is enabled, otherwise Cognite won't be accessible.
-- Make sure that in the application configuration in Azure `user impersonation` for Cognite is set under API permissions and is approved.
-- Make sure the property `tools.cognite.client_secret` is set and has a correct value. To create / obtain it you (or your Azure admin) must:
-    1. Go to the Azure Portal → Microsoft Entra ID → App registrations → Your FastAPI Backend App
-    2. In the left menu, choose Certificates & secrets
-    3. Under Client secrets, click ➕ New client secret
-    4. Give it a description and choose an expiry (6 months, 12 months, custom)
-    5. Click Add
-    Azure will show you:
-        - Value – this is your actual secret (copy it now → you can’t view it later)
-        - Secret ID – an internal reference (not needed in code)
+The solution depends on how Cognite authentication is configured.
+There are 4 ways to authenticate against Cognite, 3 of which are applicable for
+backend app deployments:
+
+1) service account authentication (`tools.cognite.client_id` must be present)  
+2) authentication with a token from a file (`tools.cognite.token_file_path` 
+   must be present)  
+3) OBO authentication (`tools.cognite.obo_client_secret` must be present),
+which is available only if the app security is enabled. In this case the Cognite
+health check is not present.  
+
+For all three, first make sure Cognite is reachable from the app host.  
+
+1) For service account authentication, make sure that `tools.cognite.client_id`,
+   `tools.cognite.client_secret` (environment variable `COGNITE_CLIENT_SECRET`),
+  `tools.cognite.tenant_id` are correct. The client secret has expiration date,
+   and must be renewed prior to it.  
+2) For authentication with a token from a file, make sure that
+  `tools.cognite.token_file_path` points to an existing non-empty file on the 
+  disk, and that the content is a valid token.  
+3) For OBO authentication:  
+   - Make sure that in the application configuration in Azure `user impersonation` for Cognite is set under API permissions and is approved.  
+   - Make sure the property `tools.cognite.obo_client_secret` (environment variable `COGNITE_OBO_CLIENT_SECRET`) is set and has a correct value.  
+   To create / obtain it you (or your Azure admin) must:  
+       1. Go to the Azure Portal → Microsoft Entra ID → App registrations → Your FastAPI Backend App  
+       2. In the left menu, choose Certificates & secrets  
+       3. Under Client secrets, click ➕ New client secret  
+       4. Give it a description and choose an expiry (6 months, 12 months, custom)  
+       5. Click Add  
+       Azure will show you:  
+           - Value – this is your actual secret (copy it now → you can’t view it later)  
+           - Secret ID – an internal reference (not needed in code)  
 
 ##### Verification
 
-Users no longer report that the calls made by the LLM agent to the tools `retrieve_time_series`, `retrieve_data_points` are failing.
+- Users no longer report that the calls made by the LLM agent to the tools `retrieve_time_series`, `retrieve_data_points` are failing.
+- If service account authentication is used, or authentication with a token from a file,
+check the response body of the `__health` endpoint, Cognite health check must have status `OK`.
 
 #### Redis can't be queried or is misconfigured
 

--- a/src/talk2powersystemllm/tools/cognite/base.py
+++ b/src/talk2powersystemllm/tools/cognite/base.py
@@ -1,12 +1,18 @@
 from abc import ABCMeta
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import jwt
 from cognite.client import CogniteClient
 from cognite.client.config import ClientConfig
-from cognite.client.credentials import CredentialProvider, OAuthInteractive
+from cognite.client.credentials import (
+    CredentialProvider,
+    OAuthClientCredentials,
+    OAuthInteractive,
+)
 from langchain_core.tools import BaseTool
+from pydantic import SecretStr
 
 
 class CogniteSession:
@@ -21,37 +27,74 @@ class CogniteSession:
         base_url: str,
         client_name: str,
         project: str,
-        token_file_path: Path | None = None,
         interactive_client_id: str | None = None,
+        client_id: str | None = None,
+        client_secret: SecretStr | None = None,
         tenant_id: str | None = None,
+        token_file_path: Path | None = None,
         obo_token: str | None = None,
     ):
         """
         Configure CogniteSession instance.
 
         Authentication is determined based on the provided parameters:
-            - If `interactive_client_id` is provided, interactive authentication is used (for dev purposes)
-            - Otherwise, `token_file_path` must be provided for client credentials authentication.
+            - If `interactive_client_id` is provided, interactive authentication is used.
+            (for dev purposes)
+            - If `client_id` is provided, service account authentication is used.
+            (for environment deployments, such as cim.ontotext)
+            - If `token_file_path` is provided, it is used for authentication.
+            (for environment deployments or RNDP)
             The token is renewed, if its about to time out.
+            - Otherwise, `obo_token` must be provided for authentication.
 
         Args:
             base_url (str): Base URL for the Cognite API.
             client_name (str): Name of the client for logging purposes.
             project (str): Cognite Data Fusion project name.
-            token_file_path (Path | None): full path on the disk to the cognite token file.
             interactive_client_id (str | None): Client ID for interactive authentication.
+            client_id (str | None): Client ID for authentication.
+            client_secret (SecretStr | None): Client secret.
             tenant_id (str | None): Azure tenant ID.
+            token_file_path (Path | None): full path on the disk to the Cognite token file.
+            obo_token (str | None): OBO authentication token.
         """
+
+        def exactly_one_is_not_none(*args: Any) -> bool:
+            return sum(a is not None for a in args) == 1
+
+        if not exactly_one_is_not_none(
+            interactive_client_id,
+            client_id,
+            token_file_path,
+            obo_token,
+        ):
+            raise ValueError(
+                "Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+                "'obo_token'!"
+            )
+
+        if client_id and not client_secret:
+            raise ValueError("'client_secret' is required!")
+
+        if (interactive_client_id or client_id) and not tenant_id:
+            raise ValueError("'tenant_id' is required!")
 
         if obo_token:
             credentials = CredentialProvider.load({"token": obo_token})
         elif token_file_path:
             self._token_file_path = token_file_path
             credentials = self._refresh()
-        elif interactive_client_id and tenant_id:
+        elif interactive_client_id:
             credentials = OAuthInteractive(
                 authority_url=f"https://login.microsoftonline.com/{tenant_id}",
                 client_id=interactive_client_id,
+                scopes=[f"{base_url}/.default"],
+            )
+        elif client_id:
+            credentials = OAuthClientCredentials(
+                token_url=f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+                client_id=client_id,
+                client_secret=client_secret.get_secret_value(),
                 scopes=[f"{base_url}/.default"],
             )
         else:

--- a/src/talk2powersystemllm/tools/cognite/retrieve_time_series.py
+++ b/src/talk2powersystemllm/tools/cognite/retrieve_time_series.py
@@ -20,10 +20,10 @@ class RetrieveTimeSeriesTool(BaseCogniteTool):
             "Defaults to 25. Set to `-1` to return all items. ",
             default=25,
         )
-        mrid: str | list[str] | None = Field(
+        rndp_mrid: str | list[str] | None = Field(
             description=(
                 "Filter time series by one or more master resource IDs (mrid). "
-                "Note: mrid is not the same as external_id."
+                "Note: RNDP_mrid is not the same as external_id."
                 "Examples: a single mrid, e.g. '105384df-9b48-3848-8fd2-97cf37575885' "
                 "or a list of multiple mrids, e.g. "
                 "['3916ae31-9f3d-af4e-8d87-87d373d8200a', 'fa58f41d-1ee2-9146-8dfc-4595cd86ed0e']"
@@ -40,7 +40,7 @@ class RetrieveTimeSeriesTool(BaseCogniteTool):
 
     name: str = "retrieve_time_series"
     description: str = (
-        "Retrieve one or more time series. Optionally, the time series can be filtered by mrid "
+        "Retrieve one or more time series. Optionally, the time series can be filtered by RNDP_mrid "
         "to fetch the corresponding external_id."
     )
     args_schema: Type[BaseModel] = ArgumentsSchema
@@ -49,22 +49,19 @@ class RetrieveTimeSeriesTool(BaseCogniteTool):
     def _run(
         self,
         limit: int | None = 25,
-        mrid: str | list[str] | None = None,
+        rndp_mrid: str | list[str] | None = None,
         run_manager: CallbackManagerForToolRun | None = None,
     ) -> str:
         try:
-            advanced_filter = None
-            if mrid is not None:
-                if isinstance(mrid, str):
-                    advanced_filter = filters.Equals(["metadata", "mrid"], mrid)
+            exists_filter = filters.Exists(["metadata", "RNDP_mrid"])
+            advanced_filter = exists_filter
+
+            if rndp_mrid is not None:
+                if isinstance(rndp_mrid, str):
+                    mrid_filter = filters.Equals(["metadata", "RNDP_mrid"], rndp_mrid)
                 else:
-                    for idx, item in enumerate(mrid):
-                        if idx == 0:
-                            advanced_filter = filters.Equals(["metadata", "mrid"], item)
-                        else:
-                            advanced_filter = advanced_filter | filters.Equals(
-                                ["metadata", "mrid"], item
-                            )
+                    mrid_filter = filters.In(["metadata", "RNDP_mrid"], rndp_mrid)
+                advanced_filter = exists_filter & mrid_filter
 
             return self.cognite_session.client().time_series.list(
                 limit=limit, advanced_filter=advanced_filter

--- a/tests/unit_tests/test_agent.py
+++ b/tests/unit_tests/test_agent.py
@@ -1,10 +1,11 @@
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from pydantic import SecretStr
 
-from talk2powersystemllm.agent import LLMSettings, LLMType
+from talk2powersystemllm.agent import CogniteSettings, LLMSettings, LLMType
 
 
 def test_llm_settings_openai_success():
@@ -208,13 +209,14 @@ def test_llm_settings_env_prefix_loading():
     with patch.dict(
         os.environ,
         {
-            "LLM_MODEL": "gpt-5.4",
-            "LLM_AZURE_ENDPOINT": "https://example.openai.azure.com",
-            "LLM_API_VERSION": "2024-02-15-preview",
             "LLM_API_KEY": "secret-key",
         },
     ):
-        settings = LLMSettings()
+        settings = LLMSettings(
+            model="gpt-5.4",
+            azure_endpoint="https://example.openai.azure.com",
+            api_version="2024-02-15-preview",
+        )
         assert settings.type == LLMType.azure_openai
         assert settings.model == "gpt-5.4"
         assert settings.azure_endpoint == "https://example.openai.azure.com"
@@ -270,3 +272,330 @@ def test_llm_settings_timeout_range_validation():
             use_responses_api=True,
             api_key=SecretStr("secret-key"),
         )
+
+
+def test_cognite_settings_missing_or_additional_properties():
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            interactive_client_id="123",
+            client_id="123",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            interactive_client_id="123",
+            token_file_path=Path(),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            interactive_client_id="123",
+            obo_client_secret="secret-key",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            client_id="123",
+            token_file_path=Path(),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            client_id="123",
+            obo_client_secret="secret-key",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            token_file_path=Path(),
+            obo_client_secret="secret-key",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            interactive_client_id="123",
+            client_id="123",
+            token_file_path=Path(),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            interactive_client_id="123",
+            client_id="123",
+            obo_client_secret="secret-key",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            interactive_client_id="123",
+            token_file_path=Path(),
+            obo_client_secret="secret-key",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            client_id="123",
+            token_file_path=Path(),
+            obo_client_secret="secret-key",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Pass exactly one of 'interactive_client_id', 'client_id', 'token_file_path' or "
+        "'obo_client_secret'!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            interactive_client_id="123",
+            client_id="123",
+            token_file_path=Path(),
+            obo_client_secret="secret-key",
+        )
+
+
+def test_cognite_settings_interactive_client_id_missing_tenant_id():
+    with pytest.raises(
+        ValueError,
+        match="'tenant_id' is required!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            interactive_client_id="123",
+        )
+
+
+def test_cognite_settings_interactive_client_id_success():
+    settings = CogniteSettings(
+        base_url="https://t2ps.cognitedata.com",
+        project="proj",
+        client_name="t2psclient",
+        interactive_client_id="123",
+        tenant_id="456",
+    )
+
+    assert settings.base_url == "https://t2ps.cognitedata.com"
+    assert settings.project == "proj"
+    assert settings.client_name == "t2psclient"
+    assert settings.interactive_client_id == "123"
+    assert settings.client_id is None
+    assert settings.client_secret is None
+    assert settings.tenant_id == "456"
+    assert settings.token_file_path is None
+    assert settings.obo_client_secret is None
+
+
+def test_cognite_settings_client_id_missing_secret_and_tenant_id():
+    with pytest.raises(
+        ValueError,
+        match="'client_secret' is required!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            client_id="123",
+        )
+
+
+def test_cognite_settings_client_id_missing_tenant_id():
+    with pytest.raises(
+        ValueError,
+        match="'tenant_id' is required!",
+    ):
+        CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            project="proj",
+            client_name="t2psclient",
+            client_id="123",
+            client_secret=SecretStr("secret-key"),
+        )
+
+
+def test_cognite_settings_client_id_success():
+    settings = CogniteSettings(
+        base_url="https://t2ps.cognitedata.com",
+        project="proj",
+        client_name="t2psclient",
+        client_id="123",
+        client_secret=SecretStr("secret-key"),
+        tenant_id="456",
+    )
+
+    assert settings.base_url == "https://t2ps.cognitedata.com"
+    assert settings.project == "proj"
+    assert settings.client_name == "t2psclient"
+    assert settings.interactive_client_id is None
+    assert settings.client_id == "123"
+    assert settings.client_secret.get_secret_value() == "secret-key"
+    assert settings.tenant_id == "456"
+    assert settings.token_file_path is None
+    assert settings.obo_client_secret is None
+
+
+def test_cognite_settings_token_file_path_success():
+    settings = CogniteSettings(
+        base_url="https://t2ps.cognitedata.com",
+        project="proj",
+        client_name="t2psclient",
+        token_file_path=Path(),
+    )
+
+    assert settings.base_url == "https://t2ps.cognitedata.com"
+    assert settings.project == "proj"
+    assert settings.client_name == "t2psclient"
+    assert settings.interactive_client_id is None
+    assert settings.client_id is None
+    assert settings.client_secret is None
+    assert settings.tenant_id is None
+    assert settings.token_file_path == Path()
+    assert settings.obo_client_secret is None
+
+
+def test_cognite_settings_obo_client_secret_success():
+    settings = CogniteSettings(
+        base_url="https://t2ps.cognitedata.com",
+        project="proj",
+        client_name="t2psclient",
+        obo_client_secret=SecretStr("secret-key"),
+    )
+
+    assert settings.base_url == "https://t2ps.cognitedata.com"
+    assert settings.project == "proj"
+    assert settings.client_name == "t2psclient"
+    assert settings.interactive_client_id is None
+    assert settings.client_id is None
+    assert settings.client_secret is None
+    assert settings.tenant_id is None
+    assert settings.token_file_path is None
+    assert settings.obo_client_secret.get_secret_value() == "secret-key"
+
+
+def test_cognite_settings_client_secret_env_prefix_loading():
+    with patch.dict(
+        os.environ,
+        {
+            "COGNITE_CLIENT_SECRET": "secret-key",
+        },
+    ):
+        settings = CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+            client_id="123",
+            tenant_id="456",
+        )
+
+        assert settings.base_url == "https://t2ps.cognitedata.com"
+        assert settings.project == "prod"
+        assert settings.client_name == "talk2powersystem"
+        assert settings.interactive_client_id is None
+        assert settings.client_id == "123"
+        assert settings.client_secret.get_secret_value() == "secret-key"
+        assert settings.tenant_id == "456"
+        assert settings.token_file_path is None
+        assert settings.obo_client_secret is None
+
+
+def test_cognite_settings_obo_client_secret_env_prefix_loading():
+    with patch.dict(
+        os.environ,
+        {
+            "COGNITE_OBO_CLIENT_SECRET": "secret-key",
+        },
+    ):
+        settings = CogniteSettings(
+            base_url="https://t2ps.cognitedata.com",
+        )
+
+        assert settings.base_url == "https://t2ps.cognitedata.com"
+        assert settings.project == "prod"
+        assert settings.client_name == "talk2powersystem"
+        assert settings.interactive_client_id is None
+        assert settings.client_id is None
+        assert settings.client_secret is None
+        assert settings.tenant_id is None
+        assert settings.token_file_path is None
+        assert settings.obo_client_secret.get_secret_value() == "secret-key"

--- a/tests/unit_tests/test_cognite_healthcheck.py
+++ b/tests/unit_tests/test_cognite_healthcheck.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock
+
+import pytest
+from cognite.client.data_classes import TimeSeriesList
+from cognite.client.testing import monkeypatch_cognite_client
+
+from talk2powersystemllm.app.models import HealthStatus
+from talk2powersystemllm.app.server.services import CogniteHealthchecker
+from talk2powersystemllm.tools import CogniteSession
+
+
+@pytest.mark.asyncio
+async def test_success() -> None:
+    with monkeypatch_cognite_client() as c_mock:
+        mock_session = MagicMock(spec=CogniteSession)
+        mock_session.client.return_value = c_mock
+
+        c_mock.time_series.list.return_value = TimeSeriesList._load(
+            [
+                {
+                    "id": 123,
+                    "createdTime": "2020-05-05 20:11:02.889+00:00",
+                    "lastUpdatedTime": "2026-03-20 12:52:36.275+00:00",
+                    "isStep": False,
+                    "isString": False,
+                }
+            ]
+        )
+
+        checker = CogniteHealthchecker(mock_session)
+        result = await checker.health()
+
+        assert result.status == HealthStatus.OK
+        assert result.message == "Cognite can be queried."
+
+        c_mock.time_series.list.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_error() -> None:
+    with monkeypatch_cognite_client() as c_mock:
+        mock_session = MagicMock(spec=CogniteSession)
+        mock_session.client.return_value = c_mock
+
+        c_mock.time_series.list.side_effect = Exception()
+
+        checker = CogniteHealthchecker(mock_session)
+        result = await checker.health()
+
+        assert result.status == HealthStatus.ERROR
+        assert result.message == "Cognite error "
+
+        c_mock.time_series.list.assert_called_once()


### PR DESCRIPTION
* [#363](https://github.com/statnett/Talk2PowerSystem_PM/issues/363):
  - Implement access to Cognite with a service account.
  - Environment variable `COGNITE_CLIENT_SECRET`
  (`tools.cognite.client_secret` in the agent config) used for OBO 
  authentication to Cognite is renamed to `COGNITE_OBO_CLIENT_SECRET`
  (`tools.cognite.obo_client_secret` in the agent config).
  - Bring back Cognite health check for deployments with service 
    account or with a token from a file.
    For deployments with OBO authentication, the health check is disabled.
  - Update `langchain-openai` to `1.2.0`,
    `langgraph-checkpoint-redis` to `0.4.1`, `cognite-sdk` to `8.1.0`, 
    `pydantic-settings` to `2.14.0`, `uvicorn` to `0.46.0`,
    `fastapi` to `0.136.0`, `msal` to `1.36.0`, `cachetools` to `7.0.6`, 
    `importlib_resources` to `7.1.0`, update some other transitive 
    dependencies to their latest versions to address the security 
    vulnerabilities.